### PR TITLE
Change FOR to NEEDS

### DIFF
--- a/KWRocketry/GameData/KWRocketry/KWCommunityFixes/KW_FAR.cfg
+++ b/KWRocketry/GameData/KWRocketry/KWCommunityFixes/KW_FAR.cfg
@@ -1,5 +1,5 @@
 
-@PART[KWFin]:FOR[FerramAerospaceResearch]
+@PART[KWFin]:NEEDS[FerramAerospaceResearch]:FOR[KWRocketry]
 {
 	@module = Part
 	@maximum_drag = 0
@@ -22,7 +22,7 @@
 		ctrlSurfFrac = 0.3
 	}
 }
-@PART[KWFinGC]:FOR[FerramAerospaceResearch]
+@PART[KWFinGC]:NEEDS[FerramAerospaceResearch]:FOR[KWRocketry]
 {
 	@module = Part
 	@maximum_drag = 0


### PR DESCRIPTION
FOR makes ModuleManager think that the mod exists (should be NEEDS).  Also added to the KWRocketry pass.