### PR TITLE
Lower Vesta VR-9D mass for TWR balancing reasons

### DIFF
--- a/KWRocketry/GameData/KWRocketry/Parts/Engines/2mVestaVR9D/part.cfg
+++ b/KWRocketry/GameData/KWRocketry/Parts/Engines/2mVestaVR9D/part.cfg
@@ -43,7 +43,7 @@ description = A comparitively efficient twin-nozzle upper stage packing enough o
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 5
+mass = 3.7
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2


### PR DESCRIPTION
Given the 600 kN thrust and the 340 vacuum isp, it needs a lower mass when compared to the skipper, which has a mass of 1.75, 250kN thrust and 350 isp. The proposed 3.7 tons gives it a TWR of 162 compared to the 143 of the skipper, to offset the lower isp.

Best regards,
Yemo from SETIrebalance