### PR TITLE
Category fix

### DIFF
--- a/KWRocketry/GameData/KWRocketry/Parts/Structural/KWDecoupler/5mDecoupler.cfg
+++ b/KWRocketry/GameData/KWRocketry/Parts/Structural/KWDecoupler/5mDecoupler.cfg
@@ -32,7 +32,7 @@ sound_vent_large = decouple
 TechRequired = metaMaterials
 entryCost = 8500
 cost = 1000
-category = Structural
+category = Coupling // Structural
 subcategory = 0
 title = 5m Stack Decoupler
 manufacturer = KW Rocketry
@@ -42,7 +42,7 @@ description = A low profile 5m stack decoupler.
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 3.6
+mass = 1.6 // 3.6
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2


### PR DESCRIPTION
decreased mass, a lot too much in comparison to stock & other mods for
the size of part. A KW interstage 5m with 10 times higher profile has mass of 3.75t.