### PR TITLE
Rebalancing masses of procedural fairing bases.

### DIFF
--- a/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW1875mFairingPFE.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW1875mFairingPFE.cfg
@@ -27,7 +27,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 2.5m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 1
+	mass = 0.265
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW1mFairingPFE.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW1mFairingPFE.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 1.25m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 0.25
+	mass = 0.085
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW2mFairingPFE.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW2mFairingPFE.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 2.5m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 1
+	mass = 0.215
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW3mFairingPFE.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWExpandedFairingBase/KW3mFairingPFE.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 3.75m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 2
+	mass = 0.635
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW1875mFairingPF.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW1875mFairingPF.cfg
@@ -29,7 +29,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 1.875m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 1
+	mass = 0.2385
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW1mFairingPF.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW1mFairingPF.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 1.25m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 0.25
+	mass = 0.0765
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW2mFairingPF.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW2mFairingPF.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 2.5m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 1
+	mass = 0.1935
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default

--- a/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW3mFairingPF.cfg
+++ b/GameData/KWRocketry/Parts/FairingBases/KWFairingBase/KW3mFairingPF.cfg
@@ -28,7 +28,7 @@ PART
 	manufacturer = KW Rocketry
 	description = The base upon which to mount your payload and 3.75m fairings.
 	attachRules = 1,0,1,0,0
-	mass = 2
+	mass = 0.5715
 	thermalMassModifier = 4.0
 	emissiveConstant = 0.95
 	dragModelType = default


### PR DESCRIPTION
You asked for a PR, here's my take.

For every expanded fairing base, which are most similar in capabilities to stock fairings, their mass shall equal the mass of the equivalent stock fairing plus the mass of the stock decoupler of one size below. (1m fairing + 0.625m decoupler, 2m fairing + 1.875m decoupler, etc)

For every non-expanded fairing base, which can't fan out like stock fairings do, their mass shall equal 90% of the mass of the expanded fairing of that size, to make them slightly more competitive.