### PR TITLE
Fix missing name entry for Globe SRB V

### DIFF
--- a/GameData/KWRocketry/Parts/Solids/075mAeroSRBs/KWsrbGlobeV.cfg
+++ b/GameData/KWRocketry/Parts/Solids/075mAeroSRBs/KWsrbGlobeV.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	name = 
+	name = KWsrbGlobeV
 	module = Part
 	author = KW Rocketry
 	


### PR DESCRIPTION
I had a weird bug wherein PartVolume had given all sorts of random parts a volume of 8648L exactly, and tracked it down to this part having its name entry blank.
 This apparently caused PartVolume to generate a module patch that matched any and all parts that weren't already set up, including Squad parts that were normally skipped by it.

Fix was dead simple though, the booster just needs its name entry fixed.